### PR TITLE
Closes trap selector after failing to find trap/base/etc

### DIFF
--- a/tamperMonkey/MouseHunt AutoBot blended.user.js
+++ b/tamperMonkey/MouseHunt AutoBot blended.user.js
@@ -4808,6 +4808,9 @@ function checkThenArm(sort, category, name, isForcedRetry)   //category = weapon
                 }
             }, 1000);
     }
+    else if (trapArmed === undefined && !isForcedRetry) {
+        closeTrapSelector(category);
+    }
 }
 
 function getConstToRealValue(sort, category, name) {


### PR DESCRIPTION
Adds a section so the trap selector will be closed in the event that it can't find the trap/base/charm/bait its looking for.