### PR TITLE
Fix for OUJS

### DIFF
--- a/tamperMonkey/MouseHunt AutoBot blended.user.js
+++ b/tamperMonkey/MouseHunt AutoBot blended.user.js
@@ -11,7 +11,7 @@
 // @namespace   https://greasyfork.org/users/6398, http://ooiks.com/blog/mousehunt-autobot, https://devcnn.wordpress.com/
 // @updateURL	https://greasyfork.org/scripts/32971-mousehunt-autobot-enhanced-revamp/code/MouseHunt%20AutoBot%20ENHANCED%20+%20REVAMP.meta.js
 // @downloadURL	https://greasyfork.org/scripts/32971-mousehunt-autobot-enhanced-revamp/code/MouseHunt%20AutoBot%20ENHANCED%20+%20REVAMP.user.js
-// @license 	GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
+// @license 	GPL-3.0+; http://www.gnu.org/copyleft/gpl.html
 // @include		http://mousehuntgame.com/*
 // @include		https://mousehuntgame.com/*
 // @include		http://www.mousehuntgame.com/*

--- a/tamperMonkey/MouseHunt AutoBot.user.js
+++ b/tamperMonkey/MouseHunt AutoBot.user.js
@@ -9,7 +9,7 @@
 // @namespace   https://greasyfork.org/users/6398, http://ooiks.com/blog/mousehunt-autobot
 // @updateURL	https://greasyfork.org/scripts/6092-mousehunt-autobot/code/MouseHunt%20AutoBot.meta.js
 // @downloadURL	https://greasyfork.org/scripts/6092-mousehunt-autobot/code/MouseHunt%20AutoBot.user.js
-// @license 	GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
+// @license 	GPL-3.0+; http://www.gnu.org/copyleft/gpl.html
 // @include		http://mousehuntgame.com/*
 // @include		https://mousehuntgame.com/*
 // @include		http://www.mousehuntgame.com/*


### PR DESCRIPTION
OUJS has made a change recently to require SPDX codes for OSI approved licensing.

In order to improve the appearance of your script homepages it would be appreciated if you could modify all of your affected scripts. This appears to be the two on the site... but you do have some requires elsewhere that may need some addressing.

You also seem to be out of sync with `// @name        MouseHunt AutoBot ENHANCED + REVAMP`. A reimport should fix things if you are utilizing the webhook.

Until this change is made you will be unable to update those affected scripts.

Thanks,
OUJS Staff